### PR TITLE
Address TypeError in item array manipulation

### DIFF
--- a/src/ui/components/editor/states/StateConnecting.js
+++ b/src/ui/components/editor/states/StateConnecting.js
@@ -674,7 +674,7 @@ export default class StateConnecting extends State {
     }
 
     moveConnectorToFront() {
-        const parentArray = this.schemeContainer.scheme.items;
+        let parentArray = this.schemeContainer.scheme.items;
         if (this.item.meta.parentId) {
             const parentItem = this.schemeContainer.findItemById(this.item.meta.parentId);
             if (!parentItem) {


### PR DESCRIPTION
## PR Summary
This small PR changes `parentArray` declaration from `const` to `let` to permit reassignment when a connector item has a parent,
resolving a `TypeError`.